### PR TITLE
Added Synchronous run capability to Platform Event Distributor [Breaking Change]

### DIFF
--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessAbstractAction.cls
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessAbstractAction.cls
@@ -11,21 +11,18 @@ public abstract class DomainProcessAbstractAction
     public DomainProcessAbstractAction setActionToRunInQueue( boolean isActionToRunInQueue )
     {
         this.isActionToRunInQueue = isActionToRunInQueue;
-
         return this;
     }
 
     public DomainProcessAbstractAction setNextQueueableActionInChain( IDomainProcessQueueableAction nextQueueableAction )
     {
         this.nextQueueableAction = nextQueueableAction;
-
         return this;
     }
 
     public DomainProcessAbstractAction setRecordsRequired( Boolean isRecordsRequired )
     {
         this.isRecordsRequired = isRecordsRequired;
-
         return this;
     }
 
@@ -37,31 +34,26 @@ public abstract class DomainProcessAbstractAction
     public IDomainProcessAction setRecordsToActOn( List<SObject> records )
     {
         this.records = records;
-
         return this;
     }
 
     public IDomainProcessUnitOfWorkable setUnitOfWork( IApplicationSObjectUnitOfWork uow )
     {
         this.uow = uow;
-
         return this;
     }
 
     public void run()
     {
-        if ( ( isRecordsRequired && ! this.records.isEmpty() )
-            || ! isRecordsRequired )
+        if (isRecordsRequired && this.records.isEmpty()) { return; }
+        if (this.isActionToRunInQueue)
         {
-            if (this.isActionToRunInQueue)
-            {
-                // Send it to the queue for processing later
-                System.enqueueJob( this );
-            }
-            else
-            {
-                runInProcess();
-            }
+            // Send it to the queue for processing later
+            System.enqueueJob( this );
+        }
+        else
+        {
+            runInProcess();
         }
     }
 
@@ -70,9 +62,7 @@ public abstract class DomainProcessAbstractAction
         try
         {
             this.uow = Application.UnitOfWork.newInstance();
-
             runInProcess();
-
             this.uow.commitWork();
         }
         catch (Exception e)

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls
@@ -348,11 +348,10 @@ public class DomainProcessCoordinator
                             actionClazz.setRecordsToActOn( qualifiedRecords );
 
                             // Should the action process execute in async/queueable mode?
-                            if ( currentDomainProcess.ExecuteAsynchronous__c )
-                            {
-                                ((IDomainProcessQueueableAction)actionClazz).setActionToRunInQueue( true );
+                            if (currentDomainProcess.ExecuteAsynchronous__c != null) {
+                                ((IDomainProcessQueueableAction)actionClazz).setActionToRunInQueue( currentDomainProcess.ExecuteAsynchronous__c );
                             }
-
+                            
                             if ( actionClazz instanceOf IDomainProcessUnitOfWorkable
                                 && uow != null )
                             {

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls
@@ -1,7 +1,25 @@
-public interface IEventsConsumer
-    extends Queueable
-{
-    void setEvents(List<Sobject> events);
+// All subscribers to the Platform Event Distributor process should be implementations of this interface
+// It is highly recommended, for ease of use and adoption, for implementing classes to instead implement the abstract class
+//      named PlatformEventAbstractConsumer as it implements most of the contents of this interface on your behalf,
+//      leaving only runInProcess to be implemented by an end-line a developer
+public interface IEventsConsumer extends Queueable {
+    // The following methods are to be used alongside backing properties for each value
+    // context() should return the QueueableContext identified by execution of the .execute(QueueableContext) method required by Queueable
+    QueueableContext context();
+    // isAsynchronous() is a convenience method that should return true if .execute(QueuealeContext) was called, and otherwise should return false
+    Boolean isAsynchronous();
+    // events() should return the events list passed in via the setEvents(List<SObject>) method
+    List<SObject> events();
 
+    // This method is called by PlatformEventDistributor to inject event details into the process
+    // This method is implemented in PlatformEventAbstractConsumer
+    void setEvents(List<SObject> events);
+
+    // This method is called internally by .execute(QueueableContext) and .run() methods, and is NOT called by PlatformEventDistributor
+    // This method is defined as ABSTRACT in PlatformEventAbstractConsumer, and is the only method that must be implemented when using that class as a base
     void runInProcess();
+
+    // This method is called by PlatformEventDistributor when the subscription is set to 'Execute Synchronous'
+    // This method is implemented in PlatformEventAbstractConsumer, and calls down to runInProcess() without expectation of being inside of a Queueable
+    void run();
 }

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls
@@ -2,4 +2,6 @@ public interface IEventsConsumer
     extends Queueable
 {
     void setEvents(List<Sobject> events);
+
+    void runInProcess();
 }

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls
@@ -1,25 +1,33 @@
-// All subscribers to the Platform Event Distributor process should be implementations of this interface
-// It is highly recommended, for ease of use and adoption, for implementing classes to instead implement the abstract class
-//      named PlatformEventAbstractConsumer as it implements most of the contents of this interface on your behalf,
-//      leaving only runInProcess to be implemented by an end-line a developer
+/*********************************************************************
+* @author John Daniel, Rick Parker
+* @date 2019-01-22
+*
+* @description  Interface for the EventsConsumer used by PlatformEventDistributor to inject dynamic subscribers
+*               to Platform Events
+*
+* AUTHOR         DATE        DETAIL
+* John Daniel    ????-??-??  Created
+* Rick Parker    2019-01-22  Updated to add Synchronous processing capabilities
+**********************************************************************/ 
 public interface IEventsConsumer extends Queueable {
-    // The following methods are to be used alongside backing properties for each value
-    // context() should return the QueueableContext identified by execution of the .execute(QueueableContext) method required by Queueable
-    QueueableContext context();
-    // isAsynchronous() is a convenience method that should return true if .execute(QueuealeContext) was called, and otherwise should return false
-    Boolean isAsynchronous();
-    // events() should return the events list passed in via the setEvents(List<SObject>) method
-    List<SObject> events();
+    /*******************************************************************************************************
+    * @description Adds events to the Events Consumer for use during execution
+    * @return An instantiation of IEventsConsumer, for chaining
+    *******************************************************************************************************/
+    IEventsConsumer setEvents(List<SObject> events);
 
-    // This method is called by PlatformEventDistributor to inject event details into the process
-    // This method is implemented in PlatformEventAbstractConsumer
-    void setEvents(List<SObject> events);
+    /*******************************************************************************************************
+    * @description  Sets the Events Consumer to run synchronously. By default, the Events Consumer will run as a Queueable.
+    *               Executing this method causes the Events Consumer to run in the same process without being queued. 
+    * @return An instantiation of IEventsConsumer, for chaining
+    *******************************************************************************************************/
+    IEventsConsumer setRunSynchronous();
 
-    // This method is called internally by .execute(QueueableContext) and .run() methods, and is NOT called by PlatformEventDistributor
-    // This method is defined as ABSTRACT in PlatformEventAbstractConsumer, and is the only method that must be implemented when using that class as a base
-    void runInProcess();
 
-    // This method is called by PlatformEventDistributor when the subscription is set to 'Execute Synchronous'
-    // This method is implemented in PlatformEventAbstractConsumer, and calls down to runInProcess() without expectation of being inside of a Queueable
-    void run();
+    /*******************************************************************************************************
+    * @description  This method is called by PlatformEventDistributor and is expected to either System.enqueueJob or run in process
+    *               appropriately, based upon usage of setRunSynchronous() 
+    * @return  The Id of the job being enqueued, or null if running in process
+    *******************************************************************************************************/
+    Id run();
 }

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls
@@ -1,0 +1,36 @@
+// Provides default implementation of IEventsConsumer
+public abstract class PlatformEventAbstractConsumer implements IEventsConsumer {
+    // private, backing properties
+    private List<SObject> storedEvents;
+    private QueueableContext storedContext;
+
+    // Interface required convenience methods
+    public QueueableContext context() { return storedContext; }
+    public Boolean isAsynchronous() { return storedContext != null; }
+    public List<SObject> events() { return storedEvents; }
+
+    // Constructors
+    public PlatformEventAbstractConsumer() {
+        storedEvents = new List<SObject>();
+    }
+
+    // Interface required public methods
+    public void setEvents(List<SObject> events) {
+        storedEvents = events;
+    }
+
+    // called when consumer is listed as Execute_Synchronous__c == false
+    public void execute(QueueableContext context) {
+        storedContext = context;
+        run();
+    }
+
+    // called when consumer is listed as Execute_Synchronous__c == true
+    public void run() {
+        if (storedEvents == null) { storedEvents = new List<SObject>(); }
+        runInProcess();
+    }
+
+    // Non-implemented, Interface required public methods
+    public abstract void runInProcess();
+}

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls
@@ -1,36 +1,85 @@
-// Provides default implementation of IEventsConsumer
+/*********************************************************************
+* @author Rick Parker
+* @date 2019-01-22
+*
+* @description  Default implementation of IEventsConsumer. 
+*               runInProcess() must be given a body by the implementing class.
+*
+* AUTHOR         DATE        DETAIL
+* Rick Parker    2019-01-22  Created
+**********************************************************************/ 
 public abstract class PlatformEventAbstractConsumer implements IEventsConsumer {
-    // private, backing properties
-    private List<SObject> storedEvents;
-    private QueueableContext storedContext;
+    /*******************************************************************************************************
+    * @description List of events to be processed
+    * @return List<SObject>
+    *******************************************************************************************************/
+    protected List<SObject> events = new List<SObject>();
 
-    // Interface required convenience methods
-    public QueueableContext context() { return storedContext; }
-    public Boolean isAsynchronous() { return storedContext != null; }
-    public List<SObject> events() { return storedEvents; }
+    /*******************************************************************************************************
+    * @description The QueueableContext to be executed under, if queued
+    * @return QueueableContext
+    *******************************************************************************************************/
+    protected QueueableContext context;
 
-    // Constructors
-    public PlatformEventAbstractConsumer() {
-        storedEvents = new List<SObject>();
+    /*******************************************************************************************************
+    * @description Whether the Events Consumer is being processed Synchronously, in the same process
+    * @return Boolean
+    *******************************************************************************************************/
+    protected Boolean isSynchronous = false;
+
+    /*******************************************************************************************************
+    * @description Sets the events used when processing
+    * @return IEventsConsumer, to allow chaining
+    *******************************************************************************************************/
+    public IEventsConsumer setEvents(List<SObject> events) {
+        this.events = events;
+        return this;
     }
 
-    // Interface required public methods
-    public void setEvents(List<SObject> events) {
-        storedEvents = events;
+    /*******************************************************************************************************
+    * @description Sets the processing to Synchronous
+    * @return IEventsConsumer, to allow chaining
+    *******************************************************************************************************/
+    public IEventsConsumer setRunSynchronous() {
+        isSynchronous = true;
+        return this;
     }
 
-    // called when consumer is listed as Execute_Synchronous__c == false
+    /*******************************************************************************************************
+    * @description Called when the Events Consumer is spawned as a Queueable
+    * @return void
+    *******************************************************************************************************/
     public void execute(QueueableContext context) {
-        storedContext = context;
-        run();
+        try
+        {
+            this.context = context;
+            runInProcess();
+        }
+        catch (Exception e)
+        {
+            system.debug(e);
+            system.debug(e.getStackTraceString());
+        }
     }
 
-    // called when consumer is listed as Execute_Synchronous__c == true
-    public void run() {
-        if (storedEvents == null) { storedEvents = new List<SObject>(); }
-        runInProcess();
+    /*******************************************************************************************************
+    * @description Called by the PlatformEventDistributor to spawn either a Queueable or to run in process
+    * @return Id of the queued job, if queued
+    *******************************************************************************************************/
+    public Id run() {
+        if (events == null || events.isEmpty()) { return null; }
+        if (isSynchronous) {
+            runInProcess();
+            return null;
+        }
+        else {
+            return System.enqueueJob( this );
+        }
     }
 
-    // Non-implemented, Interface required public methods
+    /*******************************************************************************************************
+    * @description Execution method where the real work is accomplished. Called by either run() or execute(context)
+    * @return void
+    *******************************************************************************************************/
     public abstract void runInProcess();
 }

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="PlatformEventAbstractConsumer">
+    <apiVersion>44.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
@@ -62,11 +62,10 @@ public class PlatformEventDistributor
         List<PlatformEvents_Subscription__mdt> eventSubscriptionRecords = new List<PlatformEvents_Subscription__mdt>();
         for
         (
-            PlatformEvents_Subscription__mdt ped
-            :
+            PlatformEvents_Subscription__mdt ped :
             [
                 select
-                    Consumer__c, EventCategory__c, Event__c, IsActive__c, MatcherRule__c, EventBus__c
+                    Consumer__c, EventCategory__c, Event__c, IsActive__c, MatcherRule__c, EventBus__c, Execute_Synchronous__c
                 from PlatformEvents_Subscription__mdt
                 where IsActive__c = true AND EventBus__c = :platformEventBusDescribe.getName()
             ]
@@ -170,9 +169,9 @@ public class PlatformEventDistributor
                     // use the setEvents() method to set the payload
                     consumer.setEvents( eventBatchForSubscriber );
 
-                    if (subscriptionRecord.Run_In_Process__c != null && subscriptionRecord.Run_In_Process__c)
+                    if (subscriptionRecord.Execute_Synchronous__c != null && subscriptionRecord.Execute_Synchronous__c)
                     {   // run consumer in process
-                        consumer.runInProcess();
+                        consumer.run();
                     }
                     else 
                     {   // enqueue the consumer class for async operation

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
@@ -166,17 +166,14 @@ public class PlatformEventDistributor
 
                     System.debug('<ojs> successfully constructed');
 
-                    // use the setEvents() method to set the payload
-                    consumer.setEvents( eventBatchForSubscriber );
+                    Id thisJob = subscriptionRecord.Execute_Synchronous__c != null && subscriptionRecord.Execute_Synchronous__c
+                        ? consumer.setEvents(eventBatchForSubscriber).setRunSynchronous().run()
+                        : consumer.setEvents(eventBatchForSubscriber).run();
+                    
+                    if (thisJob != null) {
+                        jobIdList.add( thisJob );
+                    }
 
-                    if (subscriptionRecord.Execute_Synchronous__c != null && subscriptionRecord.Execute_Synchronous__c)
-                    {   // run consumer in process
-                        consumer.run();
-                    }
-                    else 
-                    {   // enqueue the consumer class for async operation
-                        jobIdList.add(System.enqueueJob( consumer ));
-                    }
                 }
                 catch (Exception e)
                 {

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
@@ -170,8 +170,14 @@ public class PlatformEventDistributor
                     // use the setEvents() method to set the payload
                     consumer.setEvents( eventBatchForSubscriber );
 
-                    //  and then enqueue the consumer class
-                    jobIdList.add(System.enqueueJob( consumer ));
+                    if (subscriptionRecord.Run_In_Process__c != null && subscriptionRecord.Run_In_Process__c)
+                    {   // run consumer in process
+                        consumer.runInProcess();
+                    }
+                    else 
+                    {   // enqueue the consumer class for async operation
+                        jobIdList.add(System.enqueueJob( consumer ));
+                    }
                 }
                 catch (Exception e)
                 {

--- a/sfdx-source/core/main/schema/layouts/PlatformEvents_Subscription__mdt-Platform Events - Subscription Layout.layout-meta.xml
+++ b/sfdx-source/core/main/schema/layouts/PlatformEvents_Subscription__mdt-Platform Events - Subscription Layout.layout-meta.xml
@@ -40,10 +40,6 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Run_In_Process__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
                 <field>Execute_Synchronous__c</field>
             </layoutItems>
         </layoutColumns>

--- a/sfdx-source/core/main/schema/layouts/PlatformEvents_Subscription__mdt-Platform Events - Subscription Layout.layout-meta.xml
+++ b/sfdx-source/core/main/schema/layouts/PlatformEvents_Subscription__mdt-Platform Events - Subscription Layout.layout-meta.xml
@@ -38,6 +38,10 @@
                 <behavior>Required</behavior>
                 <field>Consumer__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Run_In_Process__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/sfdx-source/core/main/schema/layouts/PlatformEvents_Subscription__mdt-Platform Events - Subscription Layout.layout-meta.xml
+++ b/sfdx-source/core/main/schema/layouts/PlatformEvents_Subscription__mdt-Platform Events - Subscription Layout.layout-meta.xml
@@ -42,6 +42,10 @@
                 <behavior>Edit</behavior>
                 <field>Run_In_Process__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Execute_Synchronous__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/sfdx-source/core/main/schema/objects/PlatformEvents_Subscription__mdt/fields/Execute_Synchronous__c.field-meta.xml
+++ b/sfdx-source/core/main/schema/objects/PlatformEvents_Subscription__mdt/fields/Execute_Synchronous__c.field-meta.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Run_In_Process__c</fullName>
+    <fullName>Execute_Synchronous__c</fullName>
     <defaultValue>false</defaultValue>
     <description>When checked, the Platform Event dynamic subscription will be executed within the same process as the trigger. When unchecked, the subscribed object will be executed as a Queueable.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>When checked, the Platform Event dynamic subscription will be executed within the same process as the trigger. When unchecked, the subscribed object will be executed as a Queueable.</inlineHelpText>
-    <label>Run In Process</label>
+    <label>Execute Synchronous</label>
     <type>Checkbox</type>
 </CustomField>

--- a/sfdx-source/core/main/schema/objects/PlatformEvents_Subscription__mdt/fields/Run_In_Process__c.field-meta.xml
+++ b/sfdx-source/core/main/schema/objects/PlatformEvents_Subscription__mdt/fields/Run_In_Process__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Run_In_Process__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>When checked, the Platform Event dynamic subscription will be executed within the same process as the trigger. When unchecked, the subscribed object will be executed as a Queueable.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>When checked, the Platform Event dynamic subscription will be executed within the same process as the trigger. When unchecked, the subscribed object will be executed as a Queueable.</inlineHelpText>
+    <label>Run In Process</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/sfdx-source/reference-implementation-sales/main/classes/event-consumers/Sales_PlatformEventsConsumer.cls
+++ b/sfdx-source/reference-implementation-sales/main/classes/event-consumers/Sales_PlatformEventsConsumer.cls
@@ -1,27 +1,11 @@
-public class Sales_PlatformEventsConsumer
-    implements IEventsConsumer
-{
-    private List<SObject> eventSObjects = new List<SObject>();
-
-    // ============ IEventsConsumer implementation ============
-
-    public void setEvents(List<SObject> events)
-    {
-        System.debug('<ojs> Sales_PlatformEventsConsumer.setEvents:\n' + events);
-        this.eventSobjects = events;
-    }
-
-    // ============ Queueable implementation ============
-
-    public void execute(QueueableContext context)
-    {
-        System.debug('<ojs> Sales_PlatformEventsConsumer.execute');
-        System.debug('<ojs> eventSobjects:\n' + eventSobjects);
+public class Sales_PlatformEventsConsumer extends PlatformEventAbstractConsumer {
+    public override void runInProcess() {
+        System.debug('<ojs> Sales_PlatformEventsConsumer.runInProcess');
+        System.debug('<ojs> events:\n' + events);
 
         Set<Id> idSet = new Set<Id>();
 
-        for (SObject sobj : eventSObjects)
-        {
+        for (SObject sobj : events) {
             Event__e evt = (Event__e) sobj;
             idSet.addAll((Set<Id>) JSON.deserialize(evt.Payload__c, Set<Id>.class));
         }


### PR DESCRIPTION
This extension of functionality is considered a breaking change, due to the need for adding methods to the already existing IEventsConsumer interface. This means that any code which has already implemented this interface will be impacted by these changes, and will need to adapt.

Recommended path forward for those using Platform Event Subscription/Distributor to leverage dynamic subscribers is to implement the PlatformEventAbstractConsumer class rather than the IEventsConsumer interface directly. This will result in less work and an easier implementation. And should the IEventsConsumer be changed again in a future update, PlatformEventAbstractConsumer can be kept up to date at the same time, reducing the chances of future negative impact to end-line projects.